### PR TITLE
Fix: BE 검색 기록 상세 조회 시 isBookmarked==True 일 경우 bookmarkId 를 같이 응답으로 보냄

### DIFF
--- a/Back/app/controllers/searchHistory.controller.js
+++ b/Back/app/controllers/searchHistory.controller.js
@@ -57,19 +57,47 @@ exports.getSearchHistoryDetail = async (req, res) => {
             return res.status(404).json({ message: "Search history not found" });
         }
 
-        // 모든 이미지 URL 수집 
-        const allImageUrls = [
-            searchHistory.originalImage,
-            ...searchHistory.results.map(result => result.url)
-        ];
+        // 모든 이미지 URL 수집
+        const allImageUrls = [searchHistory.originalImage];
+        searchHistory.results.forEach(result => {
+            allImageUrls.push(result.url);
+        });
 
+        // 북마크 상태 확인
         const bookmarks = await Bookmark.find({
             userId: userId,
             imageUrl: { $in: allImageUrls }
-        }).select('imageUrl');
+        }).select('imageUrl _id');
 
-        // 북마크된 이미지 URL 집합 생성
-        const bookmarkedUrls = new Set(bookmarks.map(bookmark => bookmark.imageUrl));
+        // 북마크된 이미지 URL을 Map 저장
+        const bookmarkMap = new Map(
+            bookmarks.map(bookmark => [bookmark.imageUrl, bookmark._id])
+        );
+
+        // 원본 이미지 응답 
+        const originalImageInfo = {
+            url: searchHistory.originalImage,
+            isBookmarked: bookmarkMap.has(searchHistory.originalImage)
+        };
+
+        if (bookmarkMap.has(searchHistory.originalImage)) {
+            originalImageInfo.bookmarkId = bookmarkMap.get(searchHistory.originalImage);
+        }
+
+        //결과 이미지 응답
+        const resultImages = searchHistory.results.slice(0, 10).map(result => {
+            const resultInfo = {
+                url: result.url,
+                isBookmarked: bookmarkMap.has(result.url)
+            };
+
+            if (bookmarkMap.has(result.url)) {
+                resultInfo.bookmarkId = bookmarkMap.get(result.url);
+            }
+
+            return resultInfo;
+        });
+
 
         const response = {
             date: searchHistory.createdAt.toLocaleDateString('ko-KR', {
@@ -78,14 +106,8 @@ exports.getSearchHistoryDetail = async (req, res) => {
                 day: '2-digit'
             }).replace(/\//g, '/'),
             text: searchHistory.text,
-            originalImage: {
-                url: searchHistory.originalImage,
-                isBookmarked: bookmarkedUrls.has(searchHistory.originalImage)
-            },
-            results: searchHistory.results.slice(0, 10).map(result => ({
-                url: result.url,
-                isBookmarked: bookmarkedUrls.has(result.url)
-            }))
+            originalImage: originalImageInfo,
+            results: resultImages
         };
 
         res.status(200).json(response);


### PR DESCRIPTION
테스트한 응답 예시는 이러합니다.
{
	"date": "2024. 12. 01.",
	"text": "test_txt",
	"originalImage": {
		"url": "/uploads/original/1733053188613-original-2024-09-20 020221.png",
		"isBookmarked": false
	},
	"results": [
		{
			"url": "/uploads/results/1733053188614-result1-2024-09-20 020221.png",
			"isBookmarked": true,
			"bookmarkId": "674c4b1d4c134e00329c168b"
		},
		{
			"url": "/uploads/results/1733053188616-result2-2024-09-20 020221.png",
			"isBookmarked": false
		},
		{
			"url": "/uploads/results/1733053188618-result3-2024-09-20 020221.png",
			"isBookmarked": false
		}
	]
}